### PR TITLE
Sync XMLUtils with kodi master

### DIFF
--- a/src/util/XMLUtils.h
+++ b/src/util/XMLUtils.h
@@ -1,8 +1,8 @@
 #pragma once
 
 /*
- *      Copyright (C) 2005-2008 Team XBMC
- *      http://www.xbmc.org
+ *      Copyright (C) 2005-2013 Team XBMC
+ *      http://xbmc.org
  *
  *  This Program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -15,19 +15,19 @@
  *  GNU General Public License for more details.
  *
  *  You should have received a copy of the GNU General Public License
- *  along with XBMC; see the file COPYING.  If not, write to
- *  the Free Software Foundation, 675 Mass Ave, Cambridge, MA 02139, USA.
- *  http://www.gnu.org/copyleft/gpl.html
+ *  along with XBMC; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
  *
  */
 
-#include <platform/util/StdString.h>
+#include <string>
+#include <stdint.h>
+#include <vector>
 #include "tinyxml.h"
 
 class XMLUtils
 {
 public:
-  static bool HasUTF8Declaration(const CStdString &strXML);
   static bool HasChild(const TiXmlNode* pRootNode, const char* strTag);
 
   static bool GetHex(const TiXmlNode* pRootNode, const char* strTag, uint32_t& dwHexValue);
@@ -37,19 +37,61 @@ public:
   static bool GetDouble(const TiXmlNode* pRootNode, const char* strTag, double &value);
   static bool GetInt(const TiXmlNode* pRootNode, const char* strTag, int& iIntValue);
   static bool GetBoolean(const TiXmlNode* pRootNode, const char* strTag, bool& bBoolValue);
-  static bool GetString(const TiXmlNode* pRootNode, const char* strTag, CStdString& strStringValue);
-  static bool GetEncoding(const TiXmlDocument* pDoc, CStdString& strEncoding);
-  static bool GetPath(const TiXmlNode* pRootNode, const char* strTag, CStdString& strStringValue);
-  static bool GetFloat(const TiXmlNode* pRootNode, const char* strTag, float& value, const float min, const float max);
-  static bool GetInt(const TiXmlNode* pRootNode, const char* strTag, int& iIntValue, const int min, const int max);
+  
+  /*! \brief Get a string value from the xml tag
+   If the specified tag isn't found strStringvalue is not modified and will contain whatever
+   value it had before the method call.
 
-  static void SetString(TiXmlNode* pRootNode, const char *strTag, const CStdString& strValue);
+   \param[in]     pRootNode the xml node that contains the tag
+   \param[in]     strTag  the xml tag to read from
+   \param[in,out] strStringValue  where to store the read string
+   \return true on success, false if the tag isn't found
+   */
+  static bool GetString(const TiXmlNode* pRootNode, const char* strTag, std::string& strStringValue);
+
+  /*! \brief Get a string value from the xml tag
+      
+   \param[in]  pRootNode the xml node that contains the tag
+   \param[in]  strTag the tag to read from
+   
+   \return the value in the specified tag or an empty string if the tag isn't found
+   */
+  static std::string GetString(const TiXmlNode* pRootNode, const char* strTag);
+  /*! \brief Get multiple tags, concatenating the values together.
+   Transforms
+     <tag>value1</tag>
+     <tag clear="true">value2</tag>
+     ...
+     <tag>valuen</tag>
+   into value2<sep>...<sep>valuen, appending it to the value string. Note that <value1> is overwritten by the clear="true" tag.
+
+   \param rootNode    the parent containing the <tag>'s.
+   \param tag         the <tag> in question.
+   \param separator   the separator to use when concatenating values.
+   \param value [out] the resulting string. Remains untouched if no <tag> is available, else is appended (or cleared based on the clear parameter).
+   \param clear       if true, clears the string prior to adding tags, if tags are available. Defaults to false.
+   */
+  static bool GetAdditiveString(const TiXmlNode* rootNode, const char* tag, const std::string& separator, std::string& value, bool clear = false);
+  static bool GetStringArray(const TiXmlNode* rootNode, const char* tag, std::vector<std::string>& arrayValue, bool clear = false, const std::string& separator = "");
+  static bool GetPath(const TiXmlNode* pRootNode, const char* strTag, std::string& strStringValue);
+  static bool GetFloat(const TiXmlNode* pRootNode, const char* strTag, float& value, const float min, const float max);
+  static bool GetUInt(const TiXmlNode* pRootNode, const char* strTag, uint32_t& dwUIntValue, const uint32_t min, const uint32_t max);
+  static bool GetInt(const TiXmlNode* pRootNode, const char* strTag, int& iIntValue, const int min, const int max);
+  /*! \brief Fetch a std::string copy of an attribute, if it exists.  Cannot distinguish between empty and non-existent attributes.
+   \param element the element to query.
+   \param tag the name of the attribute.
+   \return the attribute, if it exists, else an empty string
+   */
+  static std::string GetAttribute(const TiXmlElement *element, const char *tag);
+
+  static void SetString(TiXmlNode* pRootNode, const char *strTag, const std::string& strValue);
+  static void SetAdditiveString(TiXmlNode* pRootNode, const char *strTag, const std::string& strSeparator, const std::string& strValue);
   static void SetStringArray(TiXmlNode* pRootNode, const char *strTag, const std::vector<std::string>& arrayValue);
   static void SetInt(TiXmlNode* pRootNode, const char *strTag, int value);
   static void SetFloat(TiXmlNode* pRootNode, const char *strTag, float value);
   static void SetBoolean(TiXmlNode* pRootNode, const char *strTag, bool value);
   static void SetHex(TiXmlNode* pRootNode, const char *strTag, uint32_t value);
-  static void SetPath(TiXmlNode* pRootNode, const char *strTag, const CStdString& strValue);
+  static void SetPath(TiXmlNode* pRootNode, const char *strTag, const std::string& strValue);
   static void SetLong(TiXmlNode* pRootNode, const char *strTag, long iValue);
 
   static const int path_version = 1;


### PR DESCRIPTION
This replaces the usage of `CStdString` with `std::string` so binary addons can get rid of `CStdString` while still using `XMLUtils` and socket abstraction.

I've synced `XMLUtils` with Kodi master. This adds a few new methods but also removes two xml-encoding helper methods. These methods are not used in any binary addon so I've removed them as well.
Additional the sync fixes a small bug in `XMLUtils::GetString` returning false if node-value is empty (e.g. `<foo/>`)

On linux all binary addons build fine with pvr.wmc being the exception. Adding `#include "kodi/util/StdString.h"` to pvr.wmc/src/utilities.cpp will fix it. I'll create a PR for pvr.wmc if this PR has been accepted.
