### PR TITLE
fixed: only install to multiarch paths if prefix is /usr

### DIFF
--- a/UseMultiArch.cmake
+++ b/UseMultiArch.cmake
@@ -14,7 +14,8 @@
 
 # Fedora uses lib64/ for 64-bit systems, Debian uses lib/x86_64-linux-gnu;
 # Fedora put module files in lib64/ too, but Debian uses lib/ for that
-if ("${CMAKE_SYSTEM_NAME}" MATCHES "Linux")
+if ("${CMAKE_SYSTEM_NAME}" MATCHES "Linux" AND
+    "${CMAKE_INSTALL_PREFIX}" STREQUAL "/usr")
   # Debian or Ubuntu?
   if (EXISTS "/etc/debian_version")
 	set (_libdir_def "lib/${CMAKE_LIBRARY_ARCHITECTURE}")
@@ -28,10 +29,10 @@ if ("${CMAKE_SYSTEM_NAME}" MATCHES "Linux")
 	endif (CMAKE_SIZEOF_VOID_P EQUAL 8)
 	set (_libdir_def "${_libdir_noarch}")
   endif (EXISTS "/etc/debian_version")
-else ("${CMAKE_SYSTEM_NAME}" MATCHES "Linux")
+else ()
   set (_libdir_def "lib")
   set (_libdir_noarch "lib")
-endif ("${CMAKE_SYSTEM_NAME}" MATCHES "Linux")
+endif ()
 
 # let the user override if somewhere else is desirable
 set (CMAKE_INSTALL_LIBDIR "${_libdir_def}" CACHE PATH "Object code libraries")


### PR DESCRIPTION
/usr/local et al does not do multiarch on default setups

fixes trac#15870

why didn't you fork my repo? grml. i had to hop hoops for this, and i create this bugger. not fair!
