### PR TITLE
[windows] define NOGDI so people can use ERROR in their code

### DIFF
--- a/src/windows/os-types.h
+++ b/src/windows/os-types.h
@@ -40,6 +40,7 @@
 #endif
 
 #define WIN32_LEAN_AND_MEAN           // Enable LEAN_AND_MEAN support
+#define NOGDI                         // Disable GDI support, means people can have an enum/constant named ERROR
 #ifndef NOMINMAX
 #define NOMINMAX                      // don't define min() and max() to prevent a clash with std::min() and std::max
 #endif


### PR DESCRIPTION
@akva or anyone else, is this okay? I want to get rid of it because the GDI code contains `#define ERROR 0` and I originally wanted to use it in an enum (and not as the first value).
