### PR TITLE
Added dlfcn-win32 and os-threads for windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,7 +25,10 @@ endif()
 set(kodiplatform_INCLUDE_DIRS ${TINYXML_INCLUDE_DIR} "${CMAKE_INSTALL_PREFIX}/include/kodi")
 IF(WIN32)
   LIST(APPEND kodiplatform_INCLUDE_DIRS "${CMAKE_INSTALL_PREFIX}/include/kodi/windows")
+  set(PLAT_SOURCES  src/windows/dlfcn-win32.cpp
+                    src/windows/os-threads.cpp)
 ENDIF(WIN32)
+
 set(kodiplatform_LIBRARIES ${CMAKE_THREAD_LIBS_INIT} ${TINYXML_LIBRARIES})
 
 if(NOT ${CORE_SYSTEM_NAME} STREQUAL "")

--- a/src/windows/dlfcn-win32.cpp
+++ b/src/windows/dlfcn-win32.cpp
@@ -1,0 +1,263 @@
+/*
+ * dlfcn-win32
+ * Copyright (c) 2007 Ramiro Polla
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+#include <windows.h>
+#include <stdio.h>
+
+#include "dlfcn-win32.h"
+
+/* Note:
+ * MSDN says these functions are not thread-safe. We make no efforts to have
+ * any kind of thread safety.
+ */
+
+/* I have no special reason to have set MAX_GLOBAL_OBJECTS to this value. Any
+ * comments are welcome.
+ */
+#define MAX_OBJECTS 255
+
+static HMODULE global_objects[MAX_OBJECTS];
+
+/* This function adds an object to the list of global objects.
+ * The implementation is very simple and slow.
+ * TODO: should failing this function be enough to fail the call to dlopen( )?
+ */
+static void global_object_add( HMODULE hModule )
+{
+    int i;
+
+    for( i = 0 ; i < MAX_OBJECTS ; i++ )
+    {
+        if( !global_objects[i] )
+        {
+            global_objects[i] = hModule;
+            break;
+        }
+    }
+}
+
+static void global_object_rem( HMODULE hModule )
+{
+    int i;
+
+    for( i = 0 ; i < MAX_OBJECTS ; i++ )
+    {
+        if( global_objects[i] == hModule )
+        {
+            global_objects[i] = 0;
+            break;
+        }
+    }
+}
+
+/* Argument to last function. Used in dlerror( ) */
+static char last_name[MAX_PATH];
+
+static int copy_string( char *dest, int dest_size, const char *src )
+{
+    int i = 0;
+
+    if( src && dest )
+    {
+        for( i = 0 ; i < dest_size-1 ; i++ )
+        {
+            if( !src[i] )
+                break;
+            else
+                dest[i] = src[i];
+        }
+    }
+    dest[i] = '\0';
+
+    return i;
+}
+
+void *dlopen( const char *file, int mode )
+{
+    HMODULE hModule;
+    UINT uMode;
+
+    /* Do not let Windows display the critical-error-handler message box */
+    uMode = SetErrorMode( SEM_FAILCRITICALERRORS );
+
+    if( file == 0 )
+    {
+        /* Save NULL pointer for error message */
+        _snprintf_s( last_name, MAX_PATH, MAX_PATH, "0x%p", file );
+
+        /* POSIX says that if the value of file is 0, a handle on a global
+         * symbol object must be provided. That object must be able to access
+         * all symbols from the original program file, and any objects loaded
+         * with the RTLD_GLOBAL flag.
+         * The return value from GetModuleHandle( ) allows us to retrieve
+         * symbols only from the original program file. For objects loaded with
+         * the RTLD_GLOBAL flag, we create our own list later on.
+         */
+        hModule = GetModuleHandle( NULL );
+    }
+    else
+    {
+        char lpFileName[MAX_PATH];
+        int i;
+
+        /* MSDN says backslashes *must* be used instead of forward slashes. */
+        for( i = 0 ; i < sizeof(lpFileName)-1 ; i++ )
+        {
+            if( !file[i] )
+                break;
+            else if( file[i] == '/' )
+                lpFileName[i] = '\\';
+            else
+                lpFileName[i] = file[i];
+        }
+        lpFileName[i] = '\0';
+
+        /* Save file name for error message */
+        copy_string( last_name, sizeof(last_name), lpFileName );
+
+        /* POSIX says the search path is implementation-defined.
+         * LOAD_WITH_ALTERED_SEARCH_PATH is used to make it behave more closely
+         * to UNIX's search paths (start with system folders instead of current
+         * folder).
+         */
+        hModule = LoadLibraryEx( (LPSTR) lpFileName, NULL,
+                                 LOAD_WITH_ALTERED_SEARCH_PATH );
+        /* If the object was loaded with RTLD_GLOBAL, add it to list of global
+         * objects, so that its symbols may be retrieved even if the handle for
+         * the original program file is passed. POSIX says that if the same
+         * file is specified in multiple invocations, and any of them are
+         * RTLD_GLOBAL, even if any further invocations use RTLD_LOCAL, the
+         * symbols will remain global.
+         */
+
+        if( hModule && (mode & RTLD_GLOBAL) )
+            global_object_add( hModule );
+    }
+
+    /* Return to previous state of the error-mode bit flags. */
+    SetErrorMode( uMode );
+
+    return (void *) hModule;
+}
+
+int dlclose( void *handle )
+{
+    HMODULE hModule = (HMODULE) handle;
+    BOOL ret;
+
+    /* Save handle for error message */
+    _snprintf_s( last_name, MAX_PATH, MAX_PATH, "0x%p", handle );
+
+    ret = FreeLibrary( hModule );
+
+    /* If the object was loaded with RTLD_GLOBAL, remove it from list of global
+     * objects.
+     */
+    if( ret )
+        global_object_rem( hModule );
+
+    /* dlclose's return value in inverted in relation to FreeLibrary's. */
+    ret = !ret;
+
+    return (int) ret;
+}
+
+void *dlsym( void *handle, const char *name )
+{
+    FARPROC symbol;
+    HMODULE myhandle = (HMODULE) handle;
+
+    /* Save symbol name for error message */
+    copy_string( last_name, sizeof(last_name), name );
+
+    symbol = GetProcAddress( myhandle, name );
+#if 0
+    if( symbol == NULL )
+    {
+        HMODULE hModule;
+
+        /* If the handle for the original program file is passed, also search
+         * in all globally loaded objects.
+         */
+
+        hModule = GetModuleHandle( NULL );
+
+        if( hModule == handle )
+        {
+            int i;
+           
+            for( i = 0 ; i < MAX_OBJECTS ; i++ )
+            {
+                if( global_objects[i] != 0 )
+                {
+                    symbol = GetProcAddress( global_objects[i], name );
+                    if( symbol != NULL )
+                        break;
+                }
+            }
+        }
+
+
+        CloseHandle( hModule );
+    }
+#endif
+    return (void*) symbol;
+}
+
+char *dlerror( void )
+{
+    DWORD dwMessageId;
+    /* POSIX says this function doesn't have to be thread-safe, so we use one
+     * static buffer.
+     * MSDN says the buffer cannot be larger than 64K bytes, so we set it to
+     * the limit.
+     */
+    static char lpBuffer[65535];
+    DWORD ret;
+
+    dwMessageId = GetLastError( );
+   
+    if( dwMessageId == 0 )
+        return NULL;
+
+    /* Format error message to:
+     * "<argument to function that failed>": <Windows localized error message>
+     */
+    ret  = copy_string( lpBuffer, sizeof(lpBuffer), "\"" );
+    ret += copy_string( lpBuffer+ret, sizeof(lpBuffer)-ret, last_name );
+    ret += copy_string( lpBuffer+ret, sizeof(lpBuffer)-ret, "\": " );
+    ret += FormatMessage( FORMAT_MESSAGE_FROM_SYSTEM, NULL, dwMessageId,
+                          MAKELANGID( LANG_NEUTRAL, SUBLANG_DEFAULT ),
+                          lpBuffer+ret, sizeof(lpBuffer)-ret, NULL );
+
+    if( ret > 1 )
+    {
+        /* POSIX says the string must not have trailing <newline> */
+        if( lpBuffer[ret-2] == '\r' && lpBuffer[ret-1] == '\n' )
+            lpBuffer[ret-2] = '\0';
+    }
+
+    /* POSIX says that invoking dlerror( ) a second time, immediately following
+     * a prior invocation, shall result in NULL being returned.
+     */
+    SetLastError(0);
+
+    return lpBuffer;
+}
+

--- a/src/windows/os-threads.cpp
+++ b/src/windows/os-threads.cpp
@@ -1,0 +1,136 @@
+/*
+ * This file is part of the libCEC(R) library.
+ *
+ * libCEC(R) is Copyright (C) 2011-2012 Pulse-Eight Limited.  All rights reserved.
+ * libCEC(R) is an original work, containing original code.
+ *
+ * libCEC(R) is a trademark of Pulse-Eight Limited.
+ *
+ * This program is dual-licensed; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+ *
+ *
+ * Alternatively, you can license this library under a commercial license,
+ * please contact Pulse-Eight Licensing for more information.
+ *
+ * For more information contact:
+ * Pulse-Eight Licensing       <license@pulse-eight.com>
+ *     http://www.pulse-eight.com/
+ *     http://www.pulse-eight.net/
+ */
+
+#include "../os.h"
+#include "os-threads.h"
+using namespace PLATFORM;
+
+static ConditionArg                     g_InitializeConditionVariable;
+static ConditionArg                     g_WakeConditionVariable;
+static ConditionArg                     g_WakeAllConditionVariable;
+static ConditionMutexArg                g_SleepConditionVariableCS;
+
+// check whether vista+ conditions are available at runtime
+static bool CheckVistaConditionFunctions(void)
+{
+  static int iHasVistaConditionFunctions(-1);
+  if (iHasVistaConditionFunctions == -1)
+  {
+    HMODULE handle = GetModuleHandle("Kernel32");
+    if (handle == NULL)
+    {
+      iHasVistaConditionFunctions = 0;
+    }
+    else
+    {
+      g_InitializeConditionVariable = (ConditionArg)     GetProcAddress(handle,"InitializeConditionVariable");
+      g_WakeConditionVariable       = (ConditionArg)     GetProcAddress(handle,"WakeConditionVariable");
+      g_WakeAllConditionVariable    = (ConditionArg)     GetProcAddress(handle,"WakeAllConditionVariable");
+      g_SleepConditionVariableCS    = (ConditionMutexArg)GetProcAddress(handle,"SleepConditionVariableCS");
+
+      // 1 when everything is resolved, 0 otherwise
+      iHasVistaConditionFunctions = g_InitializeConditionVariable &&
+                                    g_WakeConditionVariable &&
+                                    g_WakeAllConditionVariable &&
+                                    g_SleepConditionVariableCS ? 1 : 0;
+    }
+  }
+  return iHasVistaConditionFunctions == 1;
+}
+
+CConditionImpl::CConditionImpl(void)
+{
+  m_bOnVista = CheckVistaConditionFunctions();
+  if (m_bOnVista)
+    (*g_InitializeConditionVariable)(m_conditionVista = new CONDITION_VARIABLE);
+  else
+    m_conditionPreVista = ::CreateEvent(NULL, TRUE, FALSE, NULL);
+}
+
+CConditionImpl::~CConditionImpl(void)
+{
+  if (m_bOnVista)
+    delete m_conditionVista;
+  else
+    ::CloseHandle(m_conditionPreVista);
+}
+
+void CConditionImpl::Signal(void)
+{
+  if (m_bOnVista)
+    (*g_WakeConditionVariable)(m_conditionVista);
+  else
+    ::SetEvent(m_conditionPreVista);
+}
+
+void CConditionImpl::Broadcast(void)
+{
+  if (m_bOnVista)
+    (*g_WakeAllConditionVariable)(m_conditionVista);
+  else
+    ::SetEvent(m_conditionPreVista);
+}
+
+bool CConditionImpl::Wait(mutex_t &mutex)
+{
+  if (m_bOnVista)
+  {
+    return ((*g_SleepConditionVariableCS)(m_conditionVista, mutex, INFINITE) ? true : false);
+  }
+  else
+  {
+    ::ResetEvent(m_conditionPreVista);
+    MutexUnlock(mutex);
+    DWORD iWaitReturn = ::WaitForSingleObject(m_conditionPreVista, 1000);
+    MutexLock(mutex);
+    return (iWaitReturn == 0);
+  }
+}
+
+bool CConditionImpl::Wait(mutex_t &mutex, uint32_t iTimeoutMs)
+{
+  if (iTimeoutMs == 0)
+    return Wait(mutex);
+
+  if (m_bOnVista)
+  {
+    return ((*g_SleepConditionVariableCS)(m_conditionVista, mutex, iTimeoutMs) ? true : false);
+  }
+  else
+  {
+    ::ResetEvent(m_conditionPreVista);
+    MutexUnlock(mutex);
+    DWORD iWaitReturn = ::WaitForSingleObject(m_conditionPreVista, iTimeoutMs);
+    MutexLock(mutex);
+    return (iWaitReturn == 0);
+  }
+}

--- a/src/windows/os-threads.h
+++ b/src/windows/os-threads.h
@@ -1,0 +1,65 @@
+#pragma once
+/*
+ * This file is part of the libCEC(R) library.
+ *
+ * libCEC(R) is Copyright (C) 2011-2012 Pulse-Eight Limited.  All rights reserved.
+ * libCEC(R) is an original work, containing original code.
+ *
+ * libCEC(R) is a trademark of Pulse-Eight Limited.
+ *
+ * This program is dual-licensed; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+ *
+ *
+ * Alternatively, you can license this library under a commercial license,
+ * please contact Pulse-Eight Licensing for more information.
+ *
+ * For more information contact:
+ * Pulse-Eight Licensing       <license@pulse-eight.com>
+ *     http://www.pulse-eight.com/
+ *     http://www.pulse-eight.net/
+ */
+
+namespace PLATFORM
+{
+  #define thread_t                                 HANDLE
+  #define ThreadsWait(thread, retVal)              (::WaitForSingleObject(thread, INFINITE) < 0)
+  #define ThreadsCreate(thread, func, arg)         ((thread = ::CreateThread(NULL, 0, (LPTHREAD_START_ROUTINE)func, arg, 0, NULL)) == NULL ? false : true)
+
+  typedef CRITICAL_SECTION* mutex_t;
+  #define MutexCreate(mutex)                       ::InitializeCriticalSection(mutex = new CRITICAL_SECTION)
+  #define MutexDelete(mutex)                       ::DeleteCriticalSection(mutex); delete mutex
+  #define MutexLock(mutex)                         ::EnterCriticalSection(mutex)
+  #define MutexTryLock(mutex)                      (::TryEnterCriticalSection(mutex) != 0)
+  #define MutexUnlock(mutex)                       ::LeaveCriticalSection(mutex)
+
+  // windows vista+ conditions
+  typedef VOID (WINAPI *ConditionArg)     (CONDITION_VARIABLE*);
+  typedef BOOL (WINAPI *ConditionMutexArg)(CONDITION_VARIABLE*, CRITICAL_SECTION*, DWORD);
+
+  class CConditionImpl
+  {
+  public:
+    CConditionImpl(void);
+    virtual ~CConditionImpl(void);
+    void Signal(void);
+    void Broadcast(void);
+    bool Wait(mutex_t &mutex);
+    bool Wait(mutex_t &mutex, uint32_t iTimeoutMs);
+
+    bool                m_bOnVista;
+    CONDITION_VARIABLE *m_conditionVista;
+    HANDLE              m_conditionPreVista;
+  };
+}


### PR DESCRIPTION
@Montellese or @opdenkamp 
This fixes the build of AudioDSP and probably other binary add-ons, the build under windows fails, because of linking errors with the missing dlfcn-win32 functions.
