### PR TITLE
[tvos] - remove iokit linkage

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,7 +30,7 @@ set(kodiplatform_LIBRARIES ${CMAKE_THREAD_LIBS_INIT} ${TINYXML_LIBRARIES})
 
 if(NOT ${CORE_SYSTEM_NAME} STREQUAL "")
   if(${CORE_SYSTEM_NAME} STREQUAL "osx" OR ${CORE_SYSTEM_NAME} STREQUAL "ios")
-    list(APPEND kodiplatform_LIBRARIES "-framework CoreVideo -framework IOKit")
+    list(APPEND kodiplatform_LIBRARIES "-framework CoreVideo")
   endif()
 endif()
 


### PR DESCRIPTION
I know linking against IOKit framework was added for a reason. But i can't find any addon in our repo that needs this atm. Also on TVOS IOKit is a private framework which we can't link to. 

I already did a binary-addons testbuild on jenkins with this and didn't see any issues.

@wsnipex @Montellese we will need a similar change to the platform repo. As far as i can see it is maintained by Pulse-Eight and @opdenkamp renamed it to platform-p8 which breaks a lot of our addons. I am not sure where to PR this change then. 
1. Are we going to fork the pulseeight repo and undo the rename? 
2. Are we stuck with the current platform version?
3. Do we need to fix all addons for matching the rename?

Any advice on how i get this change into the platform is welcome.
