### PR TITLE
update source code to use renamed platform pkg

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@ set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${PROJECT_SOURCE_DIR})
 find_package(kodi REQUIRED)
 find_package(TinyXML REQUIRED)
 find_package(Threads REQUIRED)
-find_package(platform REQUIRED)
+find_package(p8-platform REQUIRED)
 include(UseMultiArch.cmake)
 include(CheckAtomic.cmake)
 

--- a/debian/control
+++ b/debian/control
@@ -1,7 +1,7 @@
 Source: kodiplatform
 Priority: extra
 Maintainer: Arne Morten Kvarving <arne.morten.kvarving@sintef.no>
-Build-Depends: debhelper (>= 8.0.0), cmake, libtinyxml-dev, kodi-addon-dev, libplatform-dev
+Build-Depends: debhelper (>= 8.0.0), cmake, libtinyxml-dev, kodi-addon-dev, libp8-platform-dev
 Standards-Version: 3.9.2
 Section: libs
 

--- a/src/util/XMLUtils.h
+++ b/src/util/XMLUtils.h
@@ -21,7 +21,7 @@
  *
  */
 
-#include <platform/util/StdString.h>
+#include <p8-platform/util/StdString.h>
 #include "tinyxml.h"
 
 class XMLUtils


### PR DESCRIPTION
[Upsteam](https://github.com/Pulse-Eight/platform) renamed their package. After a few alternations to the kodi-platform source code, p8-platform can be integrated and used.

Test packages are built to the following locations for testing/evaluation:
http://packages.libregeek.org/SteamOS-Tools/pool/main/k/kodiplatform/
