### PR TITLE
fix errors after platform rename

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@ set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${PROJECT_SOURCE_DIR})
 find_package(kodi REQUIRED)
 find_package(TinyXML REQUIRED)
 find_package(Threads REQUIRED)
-find_package(platform REQUIRED)
+find_package(p8-platform REQUIRED)
 include(UseMultiArch.cmake)
 include(CheckAtomic.cmake)
 

--- a/src/util/XMLUtils.h
+++ b/src/util/XMLUtils.h
@@ -21,7 +21,7 @@
  *
  */
 
-#include <platform/util/StdString.h>
+#include <p8-platform/util/StdString.h>
 #include "tinyxml.h"
 
 class XMLUtils


### PR DESCRIPTION
This fixes compilation of kodi-platform after platform was renamed https://github.com/Pulse-Eight/platform/pull/20
