### PR TITLE
[fix] do not hardcode CMAKE_INSTALL_PREFIX in kodiplatform_INCLUDE_DIRS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,9 +22,9 @@ if(NOT WIN32)
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC")
 endif()
 
-set(kodiplatform_INCLUDE_DIRS ${TINYXML_INCLUDE_DIR} "${CMAKE_INSTALL_PREFIX}/include/kodi")
+set(kodiplatform_INCLUDE_DIRS ${TINYXML_INCLUDE_DIR} "$<INSTALL_INTERFACE:include/kodi>")
 IF(WIN32)
-  LIST(APPEND kodiplatform_INCLUDE_DIRS "${CMAKE_INSTALL_PREFIX}/include/kodi/windows")
+  LIST(APPEND kodiplatform_INCLUDE_DIRS "$<INSTALL_INTERFACE:include/kodi/windows>")
 ENDIF(WIN32)
 set(kodiplatform_LIBRARIES ${CMAKE_THREAD_LIBS_INIT} ${TINYXML_LIBRARIES})
 

--- a/kodiplatform-config.cmake.in
+++ b/kodiplatform-config.cmake.in
@@ -10,7 +10,7 @@
 #
 # propagate these properties from one build system to the other
 set (kodiplatform_VERSION "@kodiplatform_VERSION_MAJOR@.@kodiplatform_VERSION_MINOR@")
-set (kodiplatform_INCLUDE_DIRS @kodiplatform_INCLUDE_DIRS@ @CMAKE_INSTALL_PREFIX@/include)
+set (kodiplatform_INCLUDE_DIRS @kodiplatform_INCLUDE_DIRS@)
 set (kodiplatform_LIBRARY_DIRS "@CMAKE_LIBRARY_OUTPUT_DIRECTORY@")
 set (kodiplatform_LINKER_FLAGS "@kodiplatform_LINKER_FLAGS@")
 set (kodiplatform_CONFIG_VARS "@kodiplatform_CONFIG_VARS@")


### PR DESCRIPTION
when cross-compiling not using kodi unified depends, CMAKE_INSTALL_PREFIX is always the runtime path (in most cases - /usr). 

hardcoding it means binary addons would pull /usr/include which is not good idea ;)

this should also be done for p8-platform, I'll do that later if you say this is the right way..

@wsnipex @notspiff what do you think.
