### PR TITLE
Change find_package kodi to Kodi

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@ enable_language(CXX)
 
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${PROJECT_SOURCE_DIR})
 
-find_package(kodi REQUIRED)
+find_package(Kodi REQUIRED)
 find_package(TinyXML REQUIRED)
 find_package(Threads REQUIRED)
 find_package(p8-platform REQUIRED)

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+kodiplatform (17.1.0-1~trusty) trusty; urgency=medium
+
+  * rename find_package kodi to Kodi
+
+ -- h.udo <hudokkow@gmail.com>  Mon, 16 May 2016 10:44:56 +0000
+
 kodiplatform (17.0.0-1~trusty) trusty; urgency=medium
 
   * adjust to libplatform rename to libp8-platform

--- a/debian/changelog.in
+++ b/debian/changelog.in
@@ -1,3 +1,9 @@
+kodiplatform (17.1.0-#TAGREV#~#DIST#) #DIST#; urgency=medium
+
+  * rename find_package kodi to Kodi
+
+ -- h.udo <hudokkow@gmail.com>  Mon, 16 May 2016 10:44:56 +0000
+
 kodiplatform (17.0.0-#TAGREV#~#DIST#) #DIST#; urgency=medium
 
   * adjust to libplatform rename to libp8-platform


### PR DESCRIPTION
@wsnipex , needed for https://github.com/xbmc/xbmc/pull/9750 or build will fail with

> By not providing "Findkodi.cmake" in CMAKE_MODULE_PATH this project has asked CMake to find a package configuration file provided by "kodi", but CMake did not find one.
> Could not find a package configuration file provided by "kodi" with any of  the following names:
>     kodiConfig.cmake
>     kodi-config.cmake

Tested with http://jenkins.kodi.tv/view/Helpers/job/BuildMulti-All/1361/

Should I bump minor in debian/changelog?

btw, any reason why https://github.com/xbmc/xbmc/blob/master/project/cmake/addons/depends/common/kodi-platform/kodi-platform.txt doesn't point to master?
