### PR TITLE
Remove CStdString

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+build/
+.vscode/

--- a/src/util/XMLUtils.cpp
+++ b/src/util/XMLUtils.cpp
@@ -20,11 +20,13 @@
  */
 
 #include "XMLUtils.h"
+#include <p8-platform/util/StringUtils.h>
 
 bool XMLUtils::GetHex(const TiXmlNode* pRootNode, const char* strTag, uint32_t& hexValue)
 {
   const TiXmlNode* pNode = pRootNode->FirstChild(strTag );
-  if (!pNode || !pNode->FirstChild()) return false;
+  if (!pNode || !pNode->FirstChild())
+    return false;
   sscanf(pNode->FirstChild()->Value(), "%x", (uint32_t*) &hexValue );
   return true;
 }
@@ -33,7 +35,8 @@ bool XMLUtils::GetHex(const TiXmlNode* pRootNode, const char* strTag, uint32_t& 
 bool XMLUtils::GetUInt(const TiXmlNode* pRootNode, const char* strTag, uint32_t& uintValue)
 {
   const TiXmlNode* pNode = pRootNode->FirstChild(strTag );
-  if (!pNode || !pNode->FirstChild()) return false;
+  if (!pNode || !pNode->FirstChild())
+    return false;
   uintValue = atol(pNode->FirstChild()->Value());
   return true;
 }
@@ -41,7 +44,8 @@ bool XMLUtils::GetUInt(const TiXmlNode* pRootNode, const char* strTag, uint32_t&
 bool XMLUtils::GetLong(const TiXmlNode* pRootNode, const char* strTag, long& lLongValue)
 {
   const TiXmlNode* pNode = pRootNode->FirstChild(strTag );
-  if (!pNode || !pNode->FirstChild()) return false;
+  if (!pNode || !pNode->FirstChild())
+    return false;
   lLongValue = atol(pNode->FirstChild()->Value());
   return true;
 }
@@ -49,7 +53,8 @@ bool XMLUtils::GetLong(const TiXmlNode* pRootNode, const char* strTag, long& lLo
 bool XMLUtils::GetInt(const TiXmlNode* pRootNode, const char* strTag, int& iIntValue)
 {
   const TiXmlNode* pNode = pRootNode->FirstChild(strTag );
-  if (!pNode || !pNode->FirstChild()) return false;
+  if (!pNode || !pNode->FirstChild())
+    return false;
   iIntValue = atoi(pNode->FirstChild()->Value());
   return true;
 }
@@ -68,7 +73,8 @@ bool XMLUtils::GetInt(const TiXmlNode* pRootNode, const char* strTag, int &value
 bool XMLUtils::GetDouble(const TiXmlNode *root, const char *tag, double &value)
 {
   const TiXmlNode* node = root->FirstChild(tag);
-  if (!node || !node->FirstChild()) return false;
+  if (!node || !node->FirstChild())
+    return false;
   value = atof(node->FirstChild()->Value());
   return true;
 }
@@ -76,7 +82,8 @@ bool XMLUtils::GetDouble(const TiXmlNode *root, const char *tag, double &value)
 bool XMLUtils::GetFloat(const TiXmlNode* pRootNode, const char* strTag, float& value)
 {
   const TiXmlNode* pNode = pRootNode->FirstChild(strTag );
-  if (!pNode || !pNode->FirstChild()) return false;
+  if (!pNode || !pNode->FirstChild())
+    return false;
   value = (float)atof(pNode->FirstChild()->Value());
   return true;
 }
@@ -95,9 +102,10 @@ bool XMLUtils::GetFloat(const TiXmlNode* pRootElement, const char *tagName, floa
 bool XMLUtils::GetBoolean(const TiXmlNode* pRootNode, const char* strTag, bool& bBoolValue)
 {
   const TiXmlNode* pNode = pRootNode->FirstChild(strTag );
-  if (!pNode || !pNode->FirstChild()) return false;
-  CStdString strEnabled = pNode->FirstChild()->Value();
-  strEnabled.ToLower();
+  if (!pNode || !pNode->FirstChild())
+    return false;
+  std::string strEnabled = pNode->FirstChild()->Value();
+  StringUtils::ToLower(strEnabled);
   if (strEnabled == "off" || strEnabled == "no" || strEnabled == "disabled" || strEnabled == "false" || strEnabled == "0" )
     bBoolValue = false;
   else
@@ -109,24 +117,26 @@ bool XMLUtils::GetBoolean(const TiXmlNode* pRootNode, const char* strTag, bool& 
   return true;
 }
 
-bool XMLUtils::GetString(const TiXmlNode* pRootNode, const char* strTag, CStdString& strStringValue)
+bool XMLUtils::GetString(const TiXmlNode* pRootNode, const char* strTag, std::string& strStringValue)
 {
   const TiXmlElement* pElement = pRootNode->FirstChildElement(strTag );
-  if (!pElement) return false;
+  if (!pElement)
+    return false;
   const TiXmlNode* pNode = pElement->FirstChild();
   if (pNode != NULL)
   {
     strStringValue = pNode->Value();
     return true;
   }
-  strStringValue.Empty();
+  strStringValue.clear();
   return false;
 }
 
 bool XMLUtils::HasChild(const TiXmlNode* pRootNode, const char* strTag)
 {
   const TiXmlElement* pElement = pRootNode->FirstChildElement(strTag);
-  if (!pElement) return false;
+  if (!pElement)
+    return false;
   const TiXmlNode* pNode = pElement->FirstChild();
   return (pNode != NULL);
 }
@@ -135,38 +145,43 @@ bool XMLUtils::HasChild(const TiXmlNode* pRootNode, const char* strTag)
   Returns true if the encoding of the document is other then UTF-8.
   /param strEncoding Returns the encoding of the document. Empty if UTF-8
 */
-bool XMLUtils::GetEncoding(const TiXmlDocument* pDoc, CStdString& strEncoding)
+bool XMLUtils::GetEncoding(const TiXmlDocument* pDoc, std::string& strEncoding)
 {
   const TiXmlNode* pNode=NULL;
   while ((pNode=pDoc->IterateChildren(pNode)) && pNode->Type()!=TiXmlNode::TINYXML_DECLARATION) {}
-  if (!pNode) return false;
+  if (!pNode)
+    return false;
   const TiXmlDeclaration* pDecl=pNode->ToDeclaration();
-  if (!pDecl) return false;
+  if (!pDecl)
+    return false;
   strEncoding=pDecl->Encoding();
-  if (strEncoding.Equals("UTF-8") || strEncoding.Equals("UTF8")) strEncoding.Empty();
-  strEncoding.MakeUpper();
-  return !strEncoding.IsEmpty(); // Other encoding then UTF8?
+  if (StringUtils::EqualsNoCase(strEncoding, "UTF-8") || StringUtils::EqualsNoCase(strEncoding, "UTF8"))
+    strEncoding.clear();
+
+  StringUtils::ToUpper(strEncoding);
+  return !strEncoding.empty(); // Other encoding then UTF8?
 }
 
 /*!
   Returns true if the encoding of the document is specified as as UTF-8
   /param strXML The XML file (embedded in a string) to check.
 */
-bool XMLUtils::HasUTF8Declaration(const CStdString &strXML)
+bool XMLUtils::HasUTF8Declaration(const std::string &strXML)
 {
-  CStdString test = strXML;
-  test.ToLower();
+  std::string test = strXML;
+  StringUtils::ToLower(test);
   // test for the encoding="utf-8" string
-  if (test.Find("encoding=\"utf-8\"") >= 0)
+  if (test.find("encoding=\"utf-8\"") >= 0)
     return true;
   // TODO: test for plain UTF8 here?
   return false;
 }
 
-bool XMLUtils::GetPath(const TiXmlNode* pRootNode, const char* strTag, CStdString& strStringValue)
+bool XMLUtils::GetPath(const TiXmlNode* pRootNode, const char* strTag, std::string& strStringValue)
 {
   const TiXmlElement* pElement = pRootNode->FirstChildElement(strTag);
-  if (!pElement) return false;
+  if (!pElement)
+    return false;
 
   const TiXmlNode* pNode = pElement->FirstChild();
   if (pNode != NULL)
@@ -174,7 +189,7 @@ bool XMLUtils::GetPath(const TiXmlNode* pRootNode, const char* strTag, CStdStrin
     strStringValue = pNode->Value();
     return true;
   }
-  strStringValue.Empty();
+  strStringValue.clear();
   return false;
 }
 
@@ -184,7 +199,7 @@ void XMLUtils::SetStringArray(TiXmlNode* pRootNode, const char *strTag, const st
     SetString(pRootNode, strTag, arrayValue.at(i));
 }
 
-void XMLUtils::SetString(TiXmlNode* pRootNode, const char *strTag, const CStdString& strValue)
+void XMLUtils::SetString(TiXmlNode* pRootNode, const char *strTag, const std::string& strValue)
 {
   TiXmlElement newElement(strTag);
   TiXmlNode *pNewNode = pRootNode->InsertEndChild(newElement);
@@ -197,22 +212,19 @@ void XMLUtils::SetString(TiXmlNode* pRootNode, const char *strTag, const CStdStr
 
 void XMLUtils::SetInt(TiXmlNode* pRootNode, const char *strTag, int value)
 {
-  CStdString strValue;
-  strValue.Format("%i", value);
+  auto strValue = StringUtils::Format("%i", value);
   SetString(pRootNode, strTag, strValue);
 }
 
 void XMLUtils::SetLong(TiXmlNode* pRootNode, const char *strTag, long value)
 {
-  CStdString strValue;
-  strValue.Format("%l", value);
+  auto strValue = StringUtils::Format("%l", value);
   SetString(pRootNode, strTag, strValue);
 }
 
 void XMLUtils::SetFloat(TiXmlNode* pRootNode, const char *strTag, float value)
 {
-  CStdString strValue;
-  strValue.Format("%f", value);
+  auto strValue = StringUtils::Format("%f", value);
   SetString(pRootNode, strTag, strValue);
 }
 
@@ -223,12 +235,11 @@ void XMLUtils::SetBoolean(TiXmlNode* pRootNode, const char *strTag, bool value)
 
 void XMLUtils::SetHex(TiXmlNode* pRootNode, const char *strTag, uint32_t value)
 {
-  CStdString strValue;
-  strValue.Format("%x", value);
+  auto strValue = StringUtils::Format("%x", value);
   SetString(pRootNode, strTag, strValue);
 }
 
-void XMLUtils::SetPath(TiXmlNode* pRootNode, const char *strTag, const CStdString& strValue)
+void XMLUtils::SetPath(TiXmlNode* pRootNode, const char *strTag, const std::string& strValue)
 {
   TiXmlElement newElement(strTag);
   newElement.SetAttribute("pathversion", path_version);

--- a/src/util/XMLUtils.h
+++ b/src/util/XMLUtils.h
@@ -21,13 +21,14 @@
  *
  */
 
-#include <p8-platform/util/StdString.h>
+#include <string>
+#include <vector>
 #include "tinyxml.h"
 
 class XMLUtils
 {
 public:
-  static bool HasUTF8Declaration(const CStdString &strXML);
+  static bool HasUTF8Declaration(const std::string &strXML);
   static bool HasChild(const TiXmlNode* pRootNode, const char* strTag);
 
   static bool GetHex(const TiXmlNode* pRootNode, const char* strTag, uint32_t& dwHexValue);
@@ -37,19 +38,19 @@ public:
   static bool GetDouble(const TiXmlNode* pRootNode, const char* strTag, double &value);
   static bool GetInt(const TiXmlNode* pRootNode, const char* strTag, int& iIntValue);
   static bool GetBoolean(const TiXmlNode* pRootNode, const char* strTag, bool& bBoolValue);
-  static bool GetString(const TiXmlNode* pRootNode, const char* strTag, CStdString& strStringValue);
-  static bool GetEncoding(const TiXmlDocument* pDoc, CStdString& strEncoding);
-  static bool GetPath(const TiXmlNode* pRootNode, const char* strTag, CStdString& strStringValue);
+  static bool GetString(const TiXmlNode* pRootNode, const char* strTag, std::string& strStringValue);
+  static bool GetEncoding(const TiXmlDocument* pDoc, std::string& strEncoding);
+  static bool GetPath(const TiXmlNode* pRootNode, const char* strTag, std::string& strStringValue);
   static bool GetFloat(const TiXmlNode* pRootNode, const char* strTag, float& value, const float min, const float max);
   static bool GetInt(const TiXmlNode* pRootNode, const char* strTag, int& iIntValue, const int min, const int max);
 
-  static void SetString(TiXmlNode* pRootNode, const char *strTag, const CStdString& strValue);
+  static void SetString(TiXmlNode* pRootNode, const char *strTag, const std::string& strValue);
   static void SetStringArray(TiXmlNode* pRootNode, const char *strTag, const std::vector<std::string>& arrayValue);
   static void SetInt(TiXmlNode* pRootNode, const char *strTag, int value);
   static void SetFloat(TiXmlNode* pRootNode, const char *strTag, float value);
   static void SetBoolean(TiXmlNode* pRootNode, const char *strTag, bool value);
   static void SetHex(TiXmlNode* pRootNode, const char *strTag, uint32_t value);
-  static void SetPath(TiXmlNode* pRootNode, const char *strTag, const CStdString& strValue);
+  static void SetPath(TiXmlNode* pRootNode, const char *strTag, const std::string& strValue);
   static void SetLong(TiXmlNode* pRootNode, const char *strTag, long iValue);
 
   static const int path_version = 1;


### PR DESCRIPTION
Need to get rid of CStdString as it doesn't like being built with UNICODE enabled and then used as a regular std::string instead of a std::wstring.

This is part of fixing the addon build on win32. Other part is PR for p8-platform