### PR TITLE
Fix programming error

### DIFF
--- a/src/util/XMLUtils.cpp
+++ b/src/util/XMLUtils.cpp
@@ -171,7 +171,7 @@ bool XMLUtils::HasUTF8Declaration(const std::string &strXML)
   std::string test = strXML;
   StringUtils::ToLower(test);
   // test for the encoding="utf-8" string
-  if (test.find("encoding=\"utf-8\"") >= 0)
+  if (test.find("encoding=\"utf-8\"") != std::string::npos)
     return true;
   // TODO: test for plain UTF8 here?
   return false;


### PR DESCRIPTION
Warning was:

```
XMLUtils.cpp:174:39: warning:
      comparison of unsigned expression >= 0 is always true [-Wtautological-compare]
  if (test.find("encoding=\"utf-8\"") >= 0)
      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ ^  ~
```