### PR TITLE
define fixed width integer types

### DIFF
--- a/src/util/XMLUtils.h
+++ b/src/util/XMLUtils.h
@@ -21,6 +21,7 @@
  *
  */
 
+#include <cstdint>
 #include <string>
 #include <vector>
 #include "tinyxml.h"


### PR DESCRIPTION
XMLUtils uses uint32_t in public header files, but makes no attempt to define that data type.

Fix this by including <cstdint>.

Signed-off-by: Olaf Hering <olaf@aepfle.de>