### PR TITLE
Allow build with CMake 4.0.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 project(kodiplatform)
 
-cmake_minimum_required(VERSION 2.6)
+cmake_minimum_required(VERSION 3.5...4.0)
 enable_language(CXX)
 
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${PROJECT_SOURCE_DIR})


### PR DESCRIPTION
Update kodi-platform to require the same CMake as https://github.com/xbmc/xbmc/blob/master/CMakeLists.txt thus addressing the following build failure when compiling with cmake-4.0.0
```
CMake Error at CMakeLists.txt:3 (cmake_minimum_required):
  Compatibility with CMake < 3.5 has been removed from CMake.

  Update the VERSION argument <min> value.  Or, use the <min>...<max> syntax
  to tell CMake that the project requires at least <min> but has been updated
  to work with policies introduced by <max> or earlier.

  Or, add -DCMAKE_POLICY_VERSION_MINIMUM=3.5 to try configuring anyway.
```