### PR TITLE
kodiplatform-config.cmake: fix for cross-compilation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,7 +22,7 @@ if(NOT WIN32)
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC")
 endif()
 
-set(kodiplatform_INCLUDE_DIRS ${TINYXML_INCLUDE_DIR} "${CMAKE_INSTALL_PREFIX}/include/kodi")
+set(kodiplatform_INCLUDE_DIRS "${CMAKE_INSTALL_PREFIX}/include/kodi")
 IF(WIN32)
   LIST(APPEND kodiplatform_INCLUDE_DIRS "${CMAKE_INSTALL_PREFIX}/include/kodi/windows")
 ENDIF(WIN32)

--- a/kodiplatform-config.cmake.in
+++ b/kodiplatform-config.cmake.in
@@ -10,16 +10,16 @@
 #
 # propagate these properties from one build system to the other
 set (kodiplatform_VERSION "@kodiplatform_VERSION_MAJOR@.@kodiplatform_VERSION_MINOR@")
-set (kodiplatform_INCLUDE_DIRS @kodiplatform_INCLUDE_DIRS@ @CMAKE_INSTALL_PREFIX@/include)
+set (kodiplatform_INCLUDE_DIRS @TINYXML_INCLUDE_DIR@ ${CMAKE_FIND_ROOT_PATH}@kodiplatform_INCLUDE_DIRS@ ${CMAKE_FIND_ROOT_PATH}@CMAKE_INSTALL_PREFIX@/include)
 set (kodiplatform_LIBRARY_DIRS "@CMAKE_LIBRARY_OUTPUT_DIRECTORY@")
 set (kodiplatform_LINKER_FLAGS "@kodiplatform_LINKER_FLAGS@")
 set (kodiplatform_CONFIG_VARS "@kodiplatform_CONFIG_VARS@")
 
 # libraries come from the build tree where this file was generated
 if(WIN32)
-  set (kodiplatform_LIBRARY "@CMAKE_INSTALL_PREFIX@/@CMAKE_INSTALL_LIBDIR@/kodiplatform.lib")
+  set (kodiplatform_LIBRARY "${CMAKE_FIND_ROOT_PATH}@CMAKE_INSTALL_PREFIX@/@CMAKE_INSTALL_LIBDIR@/kodiplatform.lib")
 else(WIN32)
-  set (kodiplatform_LIBRARY "-L@CMAKE_INSTALL_PREFIX@/@CMAKE_INSTALL_LIBDIR@ -lkodiplatform")
+  set (kodiplatform_LIBRARY "-L${CMAKE_FIND_ROOT_PATH}@CMAKE_INSTALL_PREFIX@/@CMAKE_INSTALL_LIBDIR@ -lkodiplatform")
 endif(WIN32)
 set (kodiplatform_LIBRARIES ${kodiplatform_LIBRARY} "@kodiplatform_LIBRARIES@")
 mark_as_advanced (kodiplatform_LIBRARY)


### PR DESCRIPTION
## Description

Use CMAKE_FIND_ROOT_PATH in kodiplatform-config.cmake in order to make it cross-compilation friendly.

## Related PRs

Replaces https://github.com/xbmc/kodi-platform/pull/30

## Motivation and context

I re-opened this to test AI code review with copilot. Unfortunately it didn't support any of the languages.

So I fed the patch to Chat-GPT's new 04-mini-high model:

> The patch correctly prefixes install paths with `CMAKE_FIND_ROOT_PATH` to enable sysroot‐aware installs, but you should re‑include TinyXML for in‑tree builds, ensure all list items are properly quoted, and validate with both native and cross‑compile tests.

It got the TinyXML include wrong. It's not needed in the CMakeLists.txt because it's set in the cmake.in file.

Anyways, the patch looks correct, so I'll merge for the upcoming release.